### PR TITLE
Feature 3: loading spinner added to card

### DIFF
--- a/front/src/components/card/card.component.jsx
+++ b/front/src/components/card/card.component.jsx
@@ -1,24 +1,42 @@
-import React from 'react'
+import React, { useState, useRef } from 'react'
 import PropTypes from 'prop-types'
-import { Tile } from 'carbon-components-react';
+import { Tile, Loading } from 'carbon-components-react';
 
 import './card.styles.scss';
 
 const Card = ({ card }) => {
+
     const catGif = require('../../assets/' + card.src).default;
+    const [loading, setLoading] = useState(true);
+    const imageLoaded = () => {
+        setLoading(false);
+    }
+
     return (
         <Tile className='cat-card'>
             <div>
                 <h1>{card.title}</h1>
                 <h2>{card.type}</h2>
             </div>
-            <img src={catGif} />
+            <div style={{ display: loading ? "block" : "none" }}>
+                <Loading data-testid="loader"
+                    description="Active loading indicator"
+                    withOverlay={false}
+                />
+            </div>
+            <div style={{ display: loading ? "none" : "block" }}>
+                <img
+                    data-testid={`${card.src}`}
+                    src={catGif}
+                    onLoad={imageLoaded} />
+            </div>
+
         </Tile>
     )
 }
 
 Card.propTypes = {
-
+    card: PropTypes.object.isRequired
 }
 
 export default Card

--- a/front/src/components/card/card.test.jsx
+++ b/front/src/components/card/card.test.jsx
@@ -1,18 +1,29 @@
 import '@testing-library/jest-dom/extend-expect';
 import React from 'react';
-import { render } from '@testing-library/react';
+import { waitFor, render } from '@testing-library/react';
 import Card from './card.component';
 
 import DATA from '../../pages/data.json';
 
 describe('Testing the card component', () => {
-    it('Shoud render the card component', () => {
-        const { getByText } = render(<Card card={DATA[0]} />);
+    it('Shoud render the card component', async () => {
+        const { getByText, getByTestId } = render(<Card card={DATA[0]} />);
 
         const title = getByText(DATA[0].title);
         expect(title).toBeInTheDocument();
 
         const type = getByText(DATA[0].type);
         expect(type).toBeInTheDocument();
+
+        const image = getByTestId(DATA[0].src);
+        expect(image).toBeInTheDocument();
+    })
+
+    it('should display the spinner on loading file', () => {
+        const DUD_CAT = { type: 'None', title: 'Test', src: 'dud.gif' }
+        const { getByTestId } = render(<Card card={DUD_CAT} />);
+
+        const loader = getByTestId("loader");
+        expect(loader).toBeVisible();
     })
 })


### PR DESCRIPTION
Adds state to card to display a loading spinner when the image url is loading. As src is a static gif the loading time is too short for the loader to be visible. The loader can be seen by passing in the 'dud.gif' file in assests.